### PR TITLE
fix: finetune fever path

### DIFF
--- a/scripts/finetune_fever.sh
+++ b/scripts/finetune_fever.sh
@@ -3,7 +3,7 @@ reader=$2
 ns=$3
 dpr=$4
 
-python -m error_correction.modelling.finetune_fever \
+python -m error_correction.classifier.run \
   --model_name_or_path bert-base-uncased \
   --learning_rate $lr \
   --num_train_epochs 3 \

--- a/src/error_correction/classifier/run.py
+++ b/src/error_correction/classifier/run.py
@@ -30,6 +30,7 @@ from error_correction.modelling.callback.seq2seq_logging_callback import (
     Seq2SeqLoggingCallback,
 )
 from error_correction.modelling.lightning_base import generic_train
+from error_correction.modelling.classifier_module import FEVERClassifierModule
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
As I mentioned at https://github.com/j6mes/acl2021-factual-error-correction/issues/5#issuecomment-877628797, I think `finetune_fever` module doesn't exist. But `error_correction.classifier.run` might be same as `finetune_fever`.

So, I replaced `python -m error_correction.modelling.finetune_fever` to `python -m error_correction.classifier.run` in `finetune_fever.sh`
Also I added `from error_correction.modelling.classifier_module import FEVERClassifierModule` in `error_correction.classifier.run.py`.

In my environment, It worked well.